### PR TITLE
feat(gh-pages): add support for private github pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,96 @@ The server can be configured using environment variables:
 - `SEARCH_MAX_RESULTS`: Maximum number of search results to return (default: `10`)
 - `CACHE_BASE_PATH`: Base directory for cache storage (default: `<system-tmp>/mkdocs-mcp-cache`)
 
+### Authentication (private GitHub Pages docs)
+
+By default the server fetches documents anonymously, which works for any
+publicly published MkDocs site. For sites published as **private GitHub Pages**
+(`x-pages-private: 1` — common in GitHub Enterprise / SAML-protected orgs),
+anonymous fetches are redirected to a login page, so the search index can't be
+loaded.
+
+For these sites the server supports a `github-api` auth scheme. Instead of
+fighting the Pages cookie/SSO flow, it transparently rewrites every request
+from a GitHub Pages URL to the equivalent
+[GitHub Contents API](https://docs.github.com/en/rest/repos/contents) call,
+which **does** accept a Personal Access Token. The same `search_index.json` is
+served, so MkDocs lunr indexing, scoring, and version handling are unchanged —
+only the transport changes.
+
+#### Configuration
+
+| Env var | Required | Default | Notes |
+|---|---|---|---|
+| `MKDOCS_AUTH_TYPE` | yes | `none` | Set to `github-api` to enable the rewrite. |
+| `MKDOCS_GITHUB_TOKEN` | yes\* | — | PAT with `Contents: Read` access to the repo. Falls back to `GITHUB_TOKEN`, then `GITHUB_PERSONAL_ACCESS_TOKEN`. |
+| `MKDOCS_GITHUB_OWNER` | no | inferred | Repository owner. Inferred from the docs URL host (`https://<owner>.github.io/...`). |
+| `MKDOCS_GITHUB_REPO` | no | inferred | Repository name. Inferred from the docs URL path (`https://<owner>.github.io/<repo>/...`). |
+| `MKDOCS_GITHUB_REF` | no | `gh-pages` | Branch / tag / commit that contains the built MkDocs site (i.e. the artifact `mkdocs gh-deploy` pushed). |
+| `MKDOCS_GITHUB_SUBPATH` | no | `` | Sub-directory inside the ref where the site lives (e.g. `site` if the artifact is under `site/`). |
+
+\* A token is mandatory whenever `MKDOCS_AUTH_TYPE=github-api`. The MCP server
+exits at startup if no token is found.
+
+#### Required PAT permissions
+
+- **Fine-grained tokens**: grant **Repository contents – Read-only** on the
+  specific docs repository, plus the SSO authorization for the enterprise/org
+  if applicable.
+- **Classic tokens**: grant the `repo` scope (private) or `public_repo` scope
+  (public). Make sure the token is SAML-SSO-authorized for the org if your
+  enterprise enforces SAML.
+
+#### Example MCP configuration (Claude Desktop / Cline)
+
+```json
+{
+  "mcpServers": {
+    "my-private-docs": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@serverless-dna/mkdocs-mcp",
+        "https://<owner>.github.io/<repo>",
+        "Search the private internal documentation site"
+      ],
+      "env": {
+        "MKDOCS_AUTH_TYPE": "github-api",
+        "MKDOCS_GITHUB_TOKEN": "ghp_xxxxxxxxxxxxxxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+If your site is hosted from a non-default branch (for example `main` with the
+docs under `docs/site/`), spell that out explicitly:
+
+```json
+"env": {
+  "MKDOCS_AUTH_TYPE": "github-api",
+  "MKDOCS_GITHUB_TOKEN": "ghp_...",
+  "MKDOCS_GITHUB_REF": "main",
+  "MKDOCS_GITHUB_SUBPATH": "docs/site"
+}
+```
+
+#### Cache isolation
+
+When auth is enabled, on-disk caches are placed under a subdirectory derived
+from a hash of the auth identity (token + repo + ref). This prevents two
+different identities sharing a `CACHE_BASE_PATH` from accidentally reading
+each other's cached responses.
+
+#### Why a PAT can't be used directly against `*.github.io`
+
+Private GitHub Pages requests don't honour `Authorization: Bearer <PAT>`. They
+go through a separate browser-only flow that issues a `__Host-gh_pages_session`
+cookie after validating a logged-in `_gh_sess`. Tokens cannot initiate that
+flow. The `github-api` scheme works around this by talking to `api.github.com`
+(which **does** accept PATs) and reading the rendered site straight out of the
+configured `ref` — same bytes, different transport.
+
+
 Example:
 ```bash
 SEARCH_MAX_RESULTS=20 SEARCH_CONFIDENCE_THRESHOLD=0.2 npx @serverless-dna/mkdocs-mcp https://your-doc-site.com

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@serverless-dna/mkdocs-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@serverless-dna/mkdocs-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.1",

--- a/src/services/fetch/auth.ts
+++ b/src/services/fetch/auth.ts
@@ -1,0 +1,341 @@
+/**
+ * Authentication support for the FetchService.
+ *
+ * Currently supported schemes:
+ *  - `none`        : no authentication (default, public sites)
+ *  - `github-api`  : transparently rewrite requests targeted at a GitHub Pages
+ *                    site so that they are served via the GitHub Contents REST
+ *                    API using a Personal Access Token (PAT).
+ *
+ * The "github-api" scheme is the only practical way today to read a private
+ * GitHub Pages site (`x-pages-private: 1`) using just a token, because the
+ * Pages CDN itself only honours browser session cookies — it does NOT honour
+ * `Authorization: Bearer <PAT>`. Instead of fighting that, we keep all
+ * downstream code unchanged (lunr index parsing, HTML→Markdown conversion,
+ * etc.) and just change the transport: we map a URL such as
+ *   https://<owner>.github.io/<repo>/<path>
+ * into
+ *   https://api.github.com/repos/<owner>/<repo>/contents/<built-path>?ref=<ref>
+ * with `Accept: application/vnd.github.raw` so the response body is the raw
+ * file bytes — exactly what the rest of the pipeline expects.
+ */
+import { createHash } from 'crypto';
+
+import { logger } from '../logger';
+
+/**
+ * Type marker for "no authentication required".
+ */
+export interface NoAuthConfig {
+  type: 'none';
+}
+
+/**
+ * Configuration for the github-api transport. All fields except `token` are
+ * optional and will be inferred from the request URL when it follows the
+ * conventional `https://<owner>.github.io/<repo>/...` shape.
+ */
+export interface GithubApiAuthConfig {
+  type: 'github-api';
+  /** GitHub Personal Access Token (classic or fine-grained). */
+  token: string;
+  /** Override repository owner. Inferred from URL host when not set. */
+  owner?: string;
+  /** Override repository name. Inferred from URL path when not set. */
+  repo?: string;
+  /** Branch / tag / sha that holds the built MkDocs site. Defaults to `gh-pages`. */
+  ref?: string;
+  /** Optional sub-path inside the ref (e.g. `docs/` if the site lives there). */
+  subPath?: string;
+}
+
+export type AuthConfig = NoAuthConfig | GithubApiAuthConfig;
+
+/**
+ * Result of applying authentication to an outbound request.
+ */
+export interface AuthApplied {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Owner / repo / path inferred from a `*.github.io/<repo>/...` URL.
+ */
+export interface UrlInference {
+  owner: string;
+  repo: string;
+  path: string;
+}
+
+const SUPPORTED_AUTH_TYPES = ['none', 'github-api'] as const;
+
+/**
+ * Read auth configuration from environment variables. This is intentionally
+ * permissive on success and strict on misconfiguration: if the user opts in
+ * to an auth scheme but forgets a required value, we throw at startup rather
+ * than fall back silently.
+ */
+export const loadAuthConfigFromEnv = (env: NodeJS.ProcessEnv = process.env): AuthConfig => {
+  const rawType = (env.MKDOCS_AUTH_TYPE || 'none').trim().toLowerCase();
+
+  if (rawType === '' || rawType === 'none') {
+    return { type: 'none' };
+  }
+
+  if (rawType === 'github-api') {
+    const token =
+      env.MKDOCS_GITHUB_TOKEN ||
+      env.GITHUB_TOKEN ||
+      env.GITHUB_PERSONAL_ACCESS_TOKEN;
+
+    if (!token) {
+      throw new Error(
+        'MKDOCS_AUTH_TYPE=github-api requires a token via one of: ' +
+          'MKDOCS_GITHUB_TOKEN, GITHUB_TOKEN, GITHUB_PERSONAL_ACCESS_TOKEN.'
+      );
+    }
+
+    return {
+      type: 'github-api',
+      token,
+      owner: env.MKDOCS_GITHUB_OWNER || undefined,
+      repo: env.MKDOCS_GITHUB_REPO || undefined,
+      ref: env.MKDOCS_GITHUB_REF || 'gh-pages',
+      subPath: env.MKDOCS_GITHUB_SUBPATH || '',
+    };
+  }
+
+  throw new Error(
+    `Unsupported MKDOCS_AUTH_TYPE: '${rawType}'. Supported values: ${SUPPORTED_AUTH_TYPES.join(', ')}.`
+  );
+};
+
+/**
+ * Try to extract `owner / repo / path` from a conventional GitHub Pages URL
+ * of the form `https://<owner>.github.io/<repo>/<path>`. The returned `path`
+ * is normalised so that directory-style URLs become `<dir>/index.html`,
+ * matching how MkDocs publishes sites to the `gh-pages` branch.
+ *
+ * Returns `null` for URLs that don't match the pattern (e.g. user/org pages
+ * roots, custom domains, or non-GitHub URLs).
+ */
+export const inferGithubLocation = (urlStr: string): UrlInference | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    return null;
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const ghIoMatch = host.match(/^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\.github\.io$/);
+  if (!ghIoMatch) return null;
+
+  const owner = ghIoMatch[1];
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  // For a project pages site the first segment is the repo name.
+  // The org/user root site (https://<owner>.github.io/) has no first segment,
+  // which we don't currently support — there is no repo to address.
+  if (segments.length === 0) return null;
+
+  const repo = segments[0];
+  const remainder = segments.slice(1).join('/');
+  const endsWithSlash = parsed.pathname.endsWith('/');
+
+  const path = normaliseToFile(remainder, endsWithSlash);
+  return { owner, repo, path };
+};
+
+/**
+ * Normalise a relative path inside a published MkDocs site to the file that
+ * actually exists in the `gh-pages` branch. MkDocs (with `use_directory_urls`,
+ * the default) emits every page as `<page>/index.html`, so:
+ *   ''               (root, with or without trailing slash) -> 'index.html'
+ *   'foo/' or 'foo'  (no extension)                          -> 'foo/index.html'
+ *   'foo/bar.json'                                            -> 'foo/bar.json'
+ */
+const normaliseToFile = (relativePath: string, endsWithSlash: boolean): string => {
+  if (relativePath === '') return 'index.html';
+
+  if (endsWithSlash) {
+    return `${relativePath}/index.html`;
+  }
+
+  const lastSegment = relativePath.split('/').pop() || '';
+  if (!lastSegment.includes('.')) {
+    return `${relativePath}/index.html`;
+  }
+
+  return relativePath;
+};
+
+/**
+ * Apply the configured auth to an outbound request, returning the (possibly
+ * rewritten) URL and the (possibly augmented) headers. Pure function — no
+ * side effects, easy to test.
+ */
+export const applyAuthToRequest = (
+  urlStr: string,
+  headers: Record<string, string> | Headers | undefined,
+  config: AuthConfig
+): AuthApplied => {
+  const headerObj = normaliseHeaders(headers);
+
+  if (config.type === 'none') {
+    return { url: urlStr, headers: headerObj };
+  }
+
+  if (config.type === 'github-api') {
+    return rewriteToGithubApi(urlStr, headerObj, config);
+  }
+
+  return { url: urlStr, headers: headerObj };
+};
+
+const normaliseHeaders = (
+  h: Record<string, string> | Headers | undefined
+): Record<string, string> => {
+  if (!h) return {};
+  // Detect Headers-like object via duck typing (Headers vs plain object).
+  const maybeHeaders = h as { forEach?: unknown };
+  if (typeof maybeHeaders.forEach === 'function') {
+    const out: Record<string, string> = {};
+    (h as Headers).forEach((value, key) => {
+      out[key] = value;
+    });
+    return out;
+  }
+  return { ...(h as Record<string, string>) };
+};
+
+const rewriteToGithubApi = (
+  urlStr: string,
+  headers: Record<string, string>,
+  config: GithubApiAuthConfig
+): AuthApplied => {
+  let parsed: URL;
+  try {
+    parsed = new URL(urlStr);
+  } catch {
+    // Malformed URL: leave unchanged so the underlying fetcher reports the
+    // real error rather than us turning it into a confusing rewrite failure.
+    return { url: urlStr, headers };
+  }
+
+  // If the caller is already targeting api.github.com (e.g. another tool
+  // composed on top of this one), just inject auth and pass through.
+  if (parsed.hostname.toLowerCase() === 'api.github.com') {
+    return { url: urlStr, headers: { ...headers, ...buildGithubApiHeaders(config) } };
+  }
+
+  let owner: string | undefined = config.owner;
+  let repo: string | undefined = config.repo;
+  let path: string | undefined;
+
+  const inferred = inferGithubLocation(urlStr);
+  if (inferred) {
+    owner = owner || inferred.owner;
+    repo = repo || inferred.repo;
+    path = inferred.path;
+  } else if (owner && repo) {
+    // Custom domain or non-github.io URL. Use the URL path verbatim, after
+    // applying the same MkDocs directory→index.html normalisation.
+    const segments = parsed.pathname.split('/').filter(Boolean);
+    const remainder = segments.join('/');
+    path = normaliseToFile(remainder, parsed.pathname.endsWith('/') || segments.length === 0);
+  }
+
+  if (!owner || !repo || !path) {
+    // Couldn't figure out where to fetch from — leave the request untouched
+    // so that error reporting stays close to the original failure.
+    logger.debug(
+      `github-api auth: could not infer owner/repo/path from ${urlStr}; leaving request unchanged.`
+    );
+    return { url: urlStr, headers };
+  }
+
+  const subPath = (config.subPath || '').replace(/^\/+|\/+$/g, '');
+  const fullPath = subPath ? `${subPath}/${path}` : path;
+
+  const ref = config.ref || 'gh-pages';
+  const apiUrl =
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}` +
+    `/contents/${encodePathPreservingSlashes(fullPath)}` +
+    `?ref=${encodeURIComponent(ref)}`;
+
+  logger.debug(`github-api auth: rewrote ${urlStr} -> ${apiUrl}`);
+
+  return {
+    url: apiUrl,
+    headers: { ...headers, ...buildGithubApiHeaders(config) },
+  };
+};
+
+const encodePathPreservingSlashes = (p: string): string =>
+  p
+    .split('/')
+    .map((segment) => {
+      // Segments coming from URL.pathname are already percent-encoded.
+      // Decode first so we don't end up with double-encoded sequences like
+      // `%2520` for a literal space.
+      let decoded = segment;
+      try {
+        decoded = decodeURIComponent(segment);
+      } catch {
+        // Leave the segment as-is if it isn't a valid percent-encoded string.
+      }
+      return encodeURIComponent(decoded);
+    })
+    .join('/');
+
+const buildGithubApiHeaders = (config: GithubApiAuthConfig): Record<string, string> => ({
+  Authorization: `Bearer ${config.token}`,
+  // Ask GitHub for the file bytes directly. With this Accept header the
+  // response body is the raw file content, so .text() / .json() / etc.
+  // continue to work as before.
+  Accept: 'application/vnd.github.raw',
+  'X-GitHub-Api-Version': '2022-11-28',
+});
+
+/**
+ * Stable, low-cardinality identifier for an auth configuration. Used to scope
+ * on-disk caches so that two different identities sharing a `CACHE_BASE_PATH`
+ * never read each other's cached responses.
+ */
+export const authConfigCacheKey = (config: AuthConfig): string => {
+  if (config.type === 'none') return 'public';
+
+  if (config.type === 'github-api') {
+    const material = [
+      config.type,
+      config.token,
+      config.owner ?? '',
+      config.repo ?? '',
+      config.ref ?? '',
+      config.subPath ?? '',
+    ].join('|');
+    const digest = createHash('sha256').update(material).digest('hex').slice(0, 16);
+    return `gh-api-${digest}`;
+  }
+
+  return 'unknown';
+};
+
+/**
+ * Return a copy of `headers` with secrets redacted. Used for safe logging.
+ */
+export const redactAuthHeaders = (
+  headers: Record<string, string>
+): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    const lower = key.toLowerCase();
+    if (lower === 'authorization' || lower === 'cookie' || lower === 'x-api-key') {
+      out[key] = '<redacted>';
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+};

--- a/src/services/fetch/fetch.ts
+++ b/src/services/fetch/fetch.ts
@@ -11,6 +11,9 @@
  */
 import * as path from 'path';
 
+import { logger } from '../logger';
+
+import { applyAuthToRequest, AuthConfig, redactAuthHeaders } from './auth';
 import { CacheManager } from './cacheManager';
 import { CacheConfig, CacheStats, ContentType, FetchOptions, Response } from './types';
 
@@ -38,14 +41,26 @@ export class FetchService {
   private readonly cacheManager: CacheManager;
 
   /**
+   * Authentication configuration applied to every outbound request.
+   * Defaults to `{ type: 'none' }` for public sites.
+   */
+  private authConfig: AuthConfig = { type: 'none' };
+
+  /**
    * Creates a new FetchService instance with content-type specific caching
-   * 
+   *
    * @param config - Cache configuration defining base path and content type settings
+   * @param authConfig - Optional authentication configuration. When omitted the
+   *   service operates in "public" mode (no auth headers, no URL rewriting).
+   *   Auth can also be supplied later via {@link configureAuth}.
    * @throws Error if the configuration is invalid or cache directories cannot be accessed
    */
-  constructor(config: CacheConfig) {
+  constructor(config: CacheConfig, authConfig?: AuthConfig) {
     this.config = config;
     this.cacheManager = new CacheManager(config);
+    if (authConfig) {
+      this.authConfig = authConfig;
+    }
 
     // Initialize fetch instances for each content type
     if (config.contentTypes) {
@@ -130,23 +145,51 @@ export class FetchService {
    * ```
    */
   public fetchWithContentType(
-    url: string | URL, 
-    contentType: ContentType, 
+    url: string | URL,
+    contentType: ContentType,
     options?: FetchOptions
   ): Promise<Response> {
     const fetchInstance = this.fetchInstances.get(contentType);
     if (!fetchInstance) {
       throw new Error(`No fetch instance configured for content type: ${contentType}`);
     }
-    
-    // Add headers to enable conditional requests
-    const headers = options?.headers || {};
-    
+
+    // Apply authentication: this may rewrite the URL (for the github-api
+    // scheme) and/or add headers. For the default `none` scheme it is a no-op.
+    const { url: authedUrl, headers: authedHeaders } = applyAuthToRequest(
+      url.toString(),
+      options?.headers,
+      this.authConfig
+    );
+
+    if (this.authConfig.type !== 'none') {
+      logger.debug(
+        `[fetch] ${authedUrl} headers=${JSON.stringify(redactAuthHeaders(authedHeaders))}`
+      );
+    }
+
     // Perform the fetch with proper caching
-    return fetchInstance(url, {
+    return fetchInstance(authedUrl, {
       ...options,
-      headers
+      headers: authedHeaders,
     });
+  }
+
+  /**
+   * Set or replace the authentication configuration used for subsequent
+   * requests. Useful when the auth context isn't known at construction time
+   * (e.g. parsed from environment variables in a startup hook).
+   */
+  public configureAuth(authConfig: AuthConfig): void {
+    this.authConfig = authConfig;
+  }
+
+  /**
+   * Returns the currently configured auth scheme name. Exposed for diagnostics
+   * and tests; never returns secret material.
+   */
+  public getAuthType(): AuthConfig['type'] {
+    return this.authConfig.type;
   }
 
   /**

--- a/src/services/fetch/index.ts
+++ b/src/services/fetch/index.ts
@@ -1,15 +1,64 @@
 /**
- * Export the FetchService and related types from the fetch module
+ * Export the FetchService and related types from the fetch module.
+ *
+ * The singleton `fetchService` exported here is created at module-load time
+ * with the global cache configuration. Authentication is read from environment
+ * variables and applied automatically — for public sites this is a no-op, for
+ * the `github-api` scheme it injects the PAT and rewrites GitHub Pages URLs
+ * to the GitHub Contents API. The on-disk cache is namespaced by the auth
+ * identity so that two different identities sharing a CACHE_BASE_PATH never
+ * read each other's cached responses.
  */
-import cacheConfig from '../../config/cache';
+import baseCacheConfig from '../../config/cache';
+import { logger } from '../logger';
 
+import { authConfigCacheKey, loadAuthConfigFromEnv } from './auth';
 import { FetchService } from './fetch';
+import type { CacheConfig } from './types';
+
+/**
+ * Build a cache config whose per-content-type paths are nested under a
+ * subdirectory derived from the auth identity. This keeps cached payloads
+ * for distinct identities (e.g. different PATs / different repos) physically
+ * separate so they cannot leak across identities.
+ */
+const namespaceCacheConfig = (config: CacheConfig, namespace: string): CacheConfig => {
+  if (!config.contentTypes) return config;
+  return {
+    ...config,
+    contentTypes: Object.fromEntries(
+      Object.entries(config.contentTypes).map(([key, value]) => [
+        key,
+        value ? { ...value, path: `${namespace}/${value.path}` } : value,
+      ])
+    ) as CacheConfig['contentTypes'],
+  };
+};
+
+let authConfig;
+try {
+  authConfig = loadAuthConfigFromEnv();
+} catch (error) {
+  // We can't reach the MCP transport from here to surface this nicely, so the
+  // best we can do is log + rethrow. Misconfiguration must not be silent —
+  // otherwise users would see "request failed" errors with no hint that the
+  // root cause was a missing token.
+  logger.error(`Failed to load auth configuration: ${error instanceof Error ? error.message : String(error)}`);
+  throw error;
+}
+
+const cacheNamespace = authConfigCacheKey(authConfig);
+const cacheConfig = namespaceCacheConfig(baseCacheConfig, cacheNamespace);
+
+if (authConfig.type !== 'none') {
+  logger.info(`FetchService auth scheme: ${authConfig.type} (cache namespace: ${cacheNamespace})`);
+}
 
 // Create and export a global instance of FetchService
-export const fetchService = new FetchService(cacheConfig);
+export const fetchService = new FetchService(cacheConfig, authConfig);
 
 // Export types and classes for when direct instantiation is needed
+export * from './auth';
 export { CacheManager } from './cacheManager';
 export { FetchService } from './fetch';
 export * from './types';
-

--- a/src/shared/SearchIndexFactory.ts
+++ b/src/shared/SearchIndexFactory.ts
@@ -255,6 +255,27 @@ export class SearchIndexFactory {
       logger.info(`📡 Search index response: ${response.status} ${response.statusText}`);
 
       if (!response.ok) {
+        // Heuristic: a private GitHub Pages site responds 200/30x with HTML
+        // (the SSO/login page) when the caller is unauthenticated. The fetch
+        // layer follows redirects and may surface this as a non-OK response,
+        // a 401/403, or even 200 with text/html. We try to give the user a
+        // useful nudge instead of just "Failed to fetch search index".
+        const contentType = response.headers.get('content-type') || '';
+        const looksLikeAuthFailure =
+          response.status === 401 ||
+          response.status === 403 ||
+          response.status === 404 ||
+          (contentType.includes('text/html') && new URL(response.url || indexUrl).hostname.toLowerCase().endsWith('github.com'));
+
+        if (looksLikeAuthFailure) {
+          throw new Error(
+            `Failed to fetch search index: ${response.status} ${response.statusText}. ` +
+              `If this is a private GitHub Pages site, set MKDOCS_AUTH_TYPE=github-api ` +
+              `and provide a token via MKDOCS_GITHUB_TOKEN / GITHUB_TOKEN / ` +
+              `GITHUB_PERSONAL_ACCESS_TOKEN with read access to the repository's gh-pages branch.`
+          );
+        }
+
         throw new Error(`Failed to fetch search index: ${response.status} ${response.statusText}`);
       }
 

--- a/tests/services/fetch/auth_test.ts
+++ b/tests/services/fetch/auth_test.ts
@@ -1,0 +1,286 @@
+import {
+  applyAuthToRequest,
+  type AuthConfig,
+  authConfigCacheKey,
+  inferGithubLocation,
+  loadAuthConfigFromEnv,
+  redactAuthHeaders,
+} from '../../../src/services/fetch/auth';
+
+describe('[auth] loadAuthConfigFromEnv', () => {
+  it('defaults to "none" when no env vars are set', () => {
+    expect(loadAuthConfigFromEnv({})).toEqual({ type: 'none' });
+  });
+
+  it('treats explicit "none" the same as unset', () => {
+    expect(loadAuthConfigFromEnv({ MKDOCS_AUTH_TYPE: 'none' })).toEqual({ type: 'none' });
+  });
+
+  it('reads github-api config from MKDOCS_GITHUB_TOKEN', () => {
+    const cfg = loadAuthConfigFromEnv({
+      MKDOCS_AUTH_TYPE: 'github-api',
+      MKDOCS_GITHUB_TOKEN: 'ghp_abc',
+    });
+    expect(cfg).toEqual({
+      type: 'github-api',
+      token: 'ghp_abc',
+      owner: undefined,
+      repo: undefined,
+      ref: 'gh-pages',
+      subPath: '',
+    });
+  });
+
+  it('falls back to GITHUB_TOKEN, then GITHUB_PERSONAL_ACCESS_TOKEN', () => {
+    const cfg1 = loadAuthConfigFromEnv({
+      MKDOCS_AUTH_TYPE: 'github-api',
+      GITHUB_TOKEN: 'gh_token',
+    });
+    expect(cfg1).toMatchObject({ type: 'github-api', token: 'gh_token' });
+
+    const cfg2 = loadAuthConfigFromEnv({
+      MKDOCS_AUTH_TYPE: 'github-api',
+      GITHUB_PERSONAL_ACCESS_TOKEN: 'pat_token',
+    });
+    expect(cfg2).toMatchObject({ type: 'github-api', token: 'pat_token' });
+  });
+
+  it('honours owner / repo / ref / subPath overrides', () => {
+    const cfg = loadAuthConfigFromEnv({
+      MKDOCS_AUTH_TYPE: 'github-api',
+      MKDOCS_GITHUB_TOKEN: 'tok',
+      MKDOCS_GITHUB_OWNER: 'acme',
+      MKDOCS_GITHUB_REPO: 'docs',
+      MKDOCS_GITHUB_REF: 'main',
+      MKDOCS_GITHUB_SUBPATH: 'site',
+    });
+    expect(cfg).toEqual({
+      type: 'github-api',
+      token: 'tok',
+      owner: 'acme',
+      repo: 'docs',
+      ref: 'main',
+      subPath: 'site',
+    });
+  });
+
+  it('throws when github-api is selected without a token', () => {
+    expect(() => loadAuthConfigFromEnv({ MKDOCS_AUTH_TYPE: 'github-api' })).toThrow(
+      /requires a token/i
+    );
+  });
+
+  it('throws on unsupported auth type', () => {
+    expect(() => loadAuthConfigFromEnv({ MKDOCS_AUTH_TYPE: 'oauth' })).toThrow(
+      /Unsupported MKDOCS_AUTH_TYPE/i
+    );
+  });
+});
+
+describe('[auth] inferGithubLocation', () => {
+  it('parses a project pages URL with no trailing path', () => {
+    expect(inferGithubLocation('https://acme.github.io/docs')).toEqual({
+      owner: 'acme',
+      repo: 'docs',
+      path: 'index.html',
+    });
+  });
+
+  it('parses a project pages URL with trailing slash on root', () => {
+    expect(inferGithubLocation('https://acme.github.io/docs/')).toEqual({
+      owner: 'acme',
+      repo: 'docs',
+      path: 'index.html',
+    });
+  });
+
+  it('normalises directory-style sub-pages to <dir>/index.html', () => {
+    expect(inferGithubLocation('https://acme.github.io/docs/getting-started/')).toEqual({
+      owner: 'acme',
+      repo: 'docs',
+      path: 'getting-started/index.html',
+    });
+  });
+
+  it('keeps real file paths as-is', () => {
+    expect(
+      inferGithubLocation('https://acme.github.io/docs/search/search_index.json')
+    ).toEqual({
+      owner: 'acme',
+      repo: 'docs',
+      path: 'search/search_index.json',
+    });
+  });
+
+  it('returns null for non-github.io hosts', () => {
+    expect(inferGithubLocation('https://example.com/foo')).toBeNull();
+  });
+
+  it('returns null for the org/user root pages site (no project segment)', () => {
+    expect(inferGithubLocation('https://acme.github.io/')).toBeNull();
+  });
+
+  it('returns null for malformed URLs', () => {
+    expect(inferGithubLocation('not a url')).toBeNull();
+  });
+});
+
+describe('[auth] applyAuthToRequest', () => {
+  const cfg: AuthConfig = {
+    type: 'github-api',
+    token: 'gh_secret',
+    ref: 'gh-pages',
+    subPath: '',
+  };
+
+  it('is a no-op for the "none" scheme', () => {
+    const out = applyAuthToRequest(
+      'https://example.com/foo',
+      { Accept: 'application/json' },
+      { type: 'none' }
+    );
+    expect(out.url).toBe('https://example.com/foo');
+    expect(out.headers).toEqual({ Accept: 'application/json' });
+  });
+
+  it('rewrites a project pages URL to the GitHub Contents API', () => {
+    const out = applyAuthToRequest(
+      'https://acme.github.io/docs/search/search_index.json',
+      { Accept: 'application/json' },
+      cfg
+    );
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme/docs/contents/search/search_index.json?ref=gh-pages'
+    );
+    expect(out.headers.Authorization).toBe('Bearer gh_secret');
+    expect(out.headers.Accept).toBe('application/vnd.github.raw');
+    expect(out.headers['X-GitHub-Api-Version']).toBe('2022-11-28');
+  });
+
+  it('uses the configured ref when overriding the default', () => {
+    const out = applyAuthToRequest('https://acme.github.io/docs/versions.json', undefined, {
+      ...cfg,
+      ref: 'main',
+    });
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme/docs/contents/versions.json?ref=main'
+    );
+  });
+
+  it('prepends configured subPath to the inferred path', () => {
+    const out = applyAuthToRequest(
+      'https://acme.github.io/docs/getting-started/',
+      undefined,
+      { ...cfg, subPath: 'site' }
+    );
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme/docs/contents/site/getting-started/index.html?ref=gh-pages'
+    );
+  });
+
+  it('strips leading/trailing slashes from subPath', () => {
+    const out = applyAuthToRequest(
+      'https://acme.github.io/docs/index.html',
+      undefined,
+      { ...cfg, subPath: '/site/' }
+    );
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme/docs/contents/site/index.html?ref=gh-pages'
+    );
+  });
+
+  it('uses owner/repo overrides when URL is a custom domain', () => {
+    const out = applyAuthToRequest(
+      'https://docs.acme.example/getting-started/',
+      undefined,
+      { ...cfg, owner: 'acme-org', repo: 'private-docs' }
+    );
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme-org/private-docs/contents/getting-started/index.html?ref=gh-pages'
+    );
+  });
+
+  it('passes through api.github.com URLs unchanged but injects auth headers', () => {
+    const out = applyAuthToRequest(
+      'https://api.github.com/repos/acme/docs/contents/foo.json?ref=gh-pages',
+      { 'User-Agent': 'cline' },
+      cfg
+    );
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme/docs/contents/foo.json?ref=gh-pages'
+    );
+    expect(out.headers.Authorization).toBe('Bearer gh_secret');
+    expect(out.headers['User-Agent']).toBe('cline');
+  });
+
+  it('leaves request unchanged when owner/repo cannot be inferred', () => {
+    const out = applyAuthToRequest('https://example.com/foo', undefined, cfg);
+    expect(out.url).toBe('https://example.com/foo');
+    expect(out.headers.Authorization).toBeUndefined();
+  });
+
+  it('encodes path segments individually but preserves slashes', () => {
+    const out = applyAuthToRequest(
+      'https://acme.github.io/docs/with space/page.html',
+      undefined,
+      cfg
+    );
+    expect(out.url).toBe(
+      'https://api.github.com/repos/acme/docs/contents/with%20space/page.html?ref=gh-pages'
+    );
+  });
+
+  it('accepts Headers-like inputs as well as plain objects', () => {
+    // Mimic the Headers iteration contract (forEach(value, key)) without
+    // actually relying on the Node-built-in Headers class so the test is
+    // independent of node-fetch / undici versions.
+    const entries: Array<[string, string]> = [['Accept', 'application/json']];
+    const headers = {
+      forEach(cb: (value: string, key: string) => void) {
+        for (const [k, v] of entries) cb(v, k);
+      },
+    } as unknown as Headers;
+
+    const out = applyAuthToRequest('https://acme.github.io/docs/index.html', headers, cfg);
+    expect(out.headers.Accept).toBe('application/vnd.github.raw');
+  });
+});
+
+describe('[auth] authConfigCacheKey', () => {
+  it('returns a stable "public" key for the none scheme', () => {
+    expect(authConfigCacheKey({ type: 'none' })).toBe('public');
+  });
+
+  it('returns a stable, prefixed hash for the github-api scheme', () => {
+    const key1 = authConfigCacheKey({ type: 'github-api', token: 't1', ref: 'gh-pages' });
+    const key2 = authConfigCacheKey({ type: 'github-api', token: 't1', ref: 'gh-pages' });
+    expect(key1).toBe(key2);
+    expect(key1.startsWith('gh-api-')).toBe(true);
+  });
+
+  it('produces a different key when any auth field differs', () => {
+    const a = authConfigCacheKey({ type: 'github-api', token: 't1', ref: 'gh-pages' });
+    const b = authConfigCacheKey({ type: 'github-api', token: 't2', ref: 'gh-pages' });
+    const c = authConfigCacheKey({ type: 'github-api', token: 't1', ref: 'main' });
+    expect(a).not.toBe(b);
+    expect(a).not.toBe(c);
+  });
+});
+
+describe('[auth] redactAuthHeaders', () => {
+  it('redacts Authorization, Cookie, and X-API-Key (case-insensitively)', () => {
+    expect(
+      redactAuthHeaders({
+        authorization: 'Bearer secret',
+        Cookie: 'session=abc',
+        'X-Api-Key': 'k',
+        'X-Other': 'visible',
+      })
+    ).toEqual({
+      authorization: '<redacted>',
+      Cookie: '<redacted>',
+      'X-Api-Key': '<redacted>',
+      'X-Other': 'visible',
+    });
+  });
+});


### PR DESCRIPTION
# Pull request

## Changelog

Adds support for private GitHub Pages MkDocs sites by introducing a `github-api` auth transport that rewrites GitHub Pages URLs to GitHub Contents API requests using a PAT. This keeps the existing MkDocs search and fetch pipeline intact while allowing private `gh-pages` content to be loaded, with cache isolation per auth identity and clearer setup documentation.

Fixes # (issue) - not created

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [x] Test coverage improvement

## How Has This Been Tested?

Added unit coverage for the new auth module, including environment config loading, GitHub Pages URL inference, GitHub Contents API URL rewriting, auth header injection, cache-key generation, and secret redaction.

Also tested with real mkdocs deployed on private GitHub Pages gated by SSO login.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes